### PR TITLE
add utf8 encoding

### DIFF
--- a/replace.go
+++ b/replace.go
@@ -19,10 +19,12 @@ func (t *replacer) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err e
 	if len(src) == 0 && atEOF {
 		return
 	}
+	lTo := len(t.to)
+	lFrom := len(t.from)
 
 	for nDst < len(dst) && nSrc < len(src) {
-		if len(src) >= len(t.from) && bytes.HasPrefix(src[nSrc:], t.from) {
-			if nDst+len(t.to) > len(dst) {
+		if len(src) >= lFrom && bytes.HasPrefix(src[nSrc:], t.from) {
+			if nDst+lTo > len(dst) {
 				err = transform.ErrShortDst
 				break
 			}
@@ -30,7 +32,11 @@ func (t *replacer) Transform(dst, src []byte, atEOF bool) (nDst, nSrc int, err e
 			if n <= 0 {
 				break
 			}
-			nSrc += n
+			if n < lFrom || lFrom < lTo {
+				nSrc += lFrom
+			} else {
+				nSrc += n
+			}
 			nDst += n
 		} else {
 			dst[nDst] = src[nSrc]

--- a/replace_test.go
+++ b/replace_test.go
@@ -47,6 +47,36 @@ func TestWriter(t *testing.T) {
 			in:   "xfoy",
 			want: "xfoy",
 		},
+		{
+			from: "foo",
+			to:   "bar",
+			in:   "fooxfooyfooz",
+			want: "barxbarybarz",
+		},
+		{
+			from: "牧羊",
+			to:   "秋田",
+			in:   "牧羊犬",
+			want: "秋田犬",
+		},
+		{
+			from: "牧羊",
+			to:   "柴",
+			in:   "牧羊犬",
+			want: "柴犬",
+		},
+		{
+			from: "柴",
+			to:   "牧羊",
+			in:   "柴犬",
+			want: "牧羊犬",
+		},
+		{
+			from: "柴",
+			to:   "牧羊",
+			in:   "柴柴犬",
+			want: "牧羊牧羊犬",
+		},
 	}
 	for _, test := range tests {
 		var buf bytes.Buffer


### PR DESCRIPTION
The replace seems not work well for utf8 encoding string. In this PR, I made workarounds for that.

Is that better to use rune instead of byte (might not work for transformer)?